### PR TITLE
Added dynamics to allow for database stored parameters when using encrypted attributes in models

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -28,6 +28,7 @@ task :default => :test
 desc "Test the #{spec.name} plugin."
 Rake::TestTask.new(:test) do |t|
   t.libs << 'lib'
+  t.libs << '.'
   t.test_files = spec.test_files
   t.verbose = true
 end

--- a/lib/encrypted_strings/asymmetric_cipher.rb
+++ b/lib/encrypted_strings/asymmetric_cipher.rb
@@ -74,10 +74,10 @@ module EncryptedStrings
     attr_reader :public_key
 
     # The algorithm to use if the key files are encrypted themselves
-    attr_accessor :algorithm
+    dynamic_accessor :algorithm
     
     # The password used during symmetric decryption of the key files
-    attr_accessor :password
+    dynamic_accessor :password
     
     # Creates a new cipher that uses an asymmetric encryption strategy.
     # 
@@ -100,7 +100,7 @@ module EncryptedStrings
       
       @public_key = options[:public_key]
       @private_key = options[:private_key]
-      @encrypt_with_private = options[:encrypt_with_private] # TODO support encryption with private key
+      @encrypt_with_private = options[:encrypt_with_private]
       
       self.private_key_file = options[:private_key_file]
       self.public_key_file  = options[:public_key_file]
@@ -171,6 +171,7 @@ module EncryptedStrings
       
       # Retrieves the private RSA from the private key
       def private_rsa
+        @private_rsa = nil if @private_key.is_a?(Proc)
         if password
           options = {:password => password} # TODO support Proc
           options[:algorithm] = algorithm if algorithm
@@ -184,6 +185,8 @@ module EncryptedStrings
       
       # Retrieves the public RSA
       def public_rsa
+        @public_rsa = nil if @public_key.is_a?(Proc) or
+          (@public_key == :derived and @private_key.is_a?(Proc))
         @public_rsa ||= if @public_key == :derived
           private_rsa.public_key
         else
@@ -192,7 +195,7 @@ module EncryptedStrings
       end
 
       def make_key(key)
-        # TODO support Proc
+        key = key[] if key.is_a?(Proc)
         if key.is_a?(OpenSSL::PKey::RSA)
           key
         else
@@ -214,6 +217,5 @@ module EncryptedStrings
         end
         send("#{type}_rsa")
       end
-
   end
 end

--- a/lib/encrypted_strings/cipher.rb
+++ b/lib/encrypted_strings/cipher.rb
@@ -3,6 +3,15 @@ module EncryptedStrings
   # assumed to be able to decrypt strings.  Note, however, that certain
   # encryption algorithms do not allow decryption.
   class Cipher
+    def self.dynamic_accessor(name)
+      eval <<-CODE
+        attr_writer :#{name}
+        def #{name}
+          @#{name}.is_a?(Proc) ? @#{name}[] : @#{name}
+        end
+      CODE
+    end
+
     # Can this string be decrypted?  Default is true.
     def can_decrypt?
       true

--- a/lib/encrypted_strings/cipher.rb
+++ b/lib/encrypted_strings/cipher.rb
@@ -7,7 +7,7 @@ module EncryptedStrings
       eval <<-CODE
         attr_writer :#{name}
         def #{name}
-          @#{name}.is_a?(Proc) ? @#{name}[] : @#{name}
+          @#{name}.respond_to?(:call) ? @#{name}[] : @#{name}
         end
       CODE
     end

--- a/lib/encrypted_strings/sha_cipher.rb
+++ b/lib/encrypted_strings/sha_cipher.rb
@@ -65,10 +65,10 @@ module EncryptedStrings
     @default_builder = lambda {|data, salt| "#{data}#{salt}"}
     
     # The algorithm to use for encryption/decryption
-    attr_accessor :algorithm
+    dynamic_accessor :algorithm
     
     # The salt value to use for encryption
-    attr_accessor :salt
+    dynamic_accessor :salt
     
     # The function to use to build the value that gets hashed
     attr_accessor :builder

--- a/lib/encrypted_strings/sha_cipher.rb
+++ b/lib/encrypted_strings/sha_cipher.rb
@@ -118,7 +118,7 @@ module EncryptedStrings
       # * String
       # * Object that responds to :salt
       def salt_value(value)
-        if value.is_a?(Proc)
+        if value.respond_to?(:call)
           value.call
         elsif value.respond_to?(:salt)
           value.salt

--- a/lib/encrypted_strings/symmetric_cipher.rb
+++ b/lib/encrypted_strings/symmetric_cipher.rb
@@ -51,11 +51,11 @@ module EncryptedStrings
     @default_algorithm = 'DES-EDE3-CBC'
     
     # The algorithm to use for encryption/decryption
-    attr_accessor :algorithm
+    dynamic_accessor :algorithm
     
     # The password that generates the key/initialization vector for the
     # algorithm
-    attr_accessor :password
+    dynamic_accessor :password
     
     # Creates a new cipher that uses a symmetric encryption strategy.
     # 
@@ -74,7 +74,7 @@ module EncryptedStrings
       
       self.algorithm = options[:algorithm]
       self.password = options[:password]
-      raise NoPasswordError if password.nil?
+      raise NoPasswordError unless options[:password]
       
       super()
     end
@@ -90,10 +90,11 @@ module EncryptedStrings
       cipher = build_cipher(:encrypt)
       [cipher.update(data) + cipher.final].pack('m')
     end
-    
+
     private
       def build_cipher(type) #:nodoc:
         cipher = OpenSSL::Cipher::Cipher.new(algorithm).send(type)
+        raise NoPasswordError if password.nil?
         cipher.pkcs5_keyivgen(password)
         cipher
       end

--- a/nbproject/private/private.properties
+++ b/nbproject/private/private.properties
@@ -1,0 +1,2 @@
+file.reference.encrypted_strings-lib=/srv/data/home/mklaus/Projects/encrypted_strings/lib
+file.reference.encrypted_strings-test=/srv/data/home/mklaus/Projects/encrypted_strings/test

--- a/nbproject/private/private.xml
+++ b/nbproject/private/private.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project-private xmlns="http://www.netbeans.org/ns/project-private/1">
+    <editor-bookmarks xmlns="http://www.netbeans.org/ns/editor-bookmarks/1"/>
+</project-private>

--- a/nbproject/project.properties
+++ b/nbproject/project.properties
@@ -1,0 +1,5 @@
+main.file=
+platform.active=Ruby_0
+source.encoding=UTF-8
+src.dir=${file.reference.encrypted_strings-lib}
+test.src.dir=${file.reference.encrypted_strings-test}

--- a/nbproject/project.xml
+++ b/nbproject/project.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://www.netbeans.org/ns/project/1">
+    <type>org.netbeans.modules.ruby.rubyproject</type>
+    <configuration>
+        <data xmlns="http://www.netbeans.org/ns/ruby-project/1">
+            <name>encrypted_strings</name>
+            <source-roots>
+                <root id="src.dir"/>
+            </source-roots>
+            <test-roots>
+                <root id="test.src.dir"/>
+            </test-roots>
+        </data>
+    </configuration>
+</project>

--- a/test/symmetric_cipher_test.rb
+++ b/test/symmetric_cipher_test.rb
@@ -97,3 +97,57 @@ class SymmetricCipherWithCustomOptionsTest < Test::Unit::TestCase
     assert_equal 'test', @symmetric_cipher.decrypt("QWz/eQ==\n")
   end
 end
+
+class SymmetricCipherWithProcsAsCustomDefaultsTest < Test::Unit::TestCase
+  def setup
+    @original_default_algorithm = EncryptedStrings::SymmetricCipher.default_algorithm
+    @original_default_password = EncryptedStrings::SymmetricCipher.default_password
+
+    @al1 = 'DES-EDE3-CFB'
+    @al2 = nil
+    @pw1 = 'secret'
+    @pw2 = nil
+
+    EncryptedStrings::SymmetricCipher.default_algorithm = proc{@al}
+    EncryptedStrings::SymmetricCipher.default_password = proc{@pw}
+    @symmetric_cipher = EncryptedStrings::SymmetricCipher.new
+  end
+
+  def test_should_use_custom_default_algorithm
+    [@al1, @al2].each do |al|
+      @al = al
+      assert_equal al, @symmetric_cipher.algorithm
+    end
+  end
+
+  def test_should_use_custom_default_password
+    [@pw1, @pw2].each do |pw|
+      @pw = pw
+      assert_equal pw, @symmetric_cipher.password
+    end
+  end
+
+  def test_should_encrypt_using_custom_default_configuration
+    @al = @al1
+    @pw = @pw1
+    assert_equal "QWz/eQ==\n", @symmetric_cipher.encrypt('test')
+  end
+
+  def test_should_not_encrypt_on_missing_password
+    @al = @al1
+    @pw = @pw2
+    assert_raise(EncryptedStrings::NoPasswordError) {@symmetric_cipher.encrypt('test')}
+  end
+
+  def test_should_not_encrypt_on_missing_algorithm
+    @al = @al2
+    @pw = @pw1
+    assert_raise(TypeError) {@symmetric_cipher.encrypt('test')}
+  end
+
+  def teardown
+    EncryptedStrings::SymmetricCipher.default_algorithm = @original_default_algorithm
+    EncryptedStrings::SymmetricCipher.default_password = @original_default_password
+  end
+end
+


### PR DESCRIPTION
Added :private_key and :public_key options to AsymmetricCipher to allow for database/memory stored keys
Added :encrypt_with_private to turn around roles for private and public key
Added :public_key => :derived option for allowing the public key to be derived from the private key file
:algorithm, :password, :salt, :private_key and :public_key now support Procs for getting the values e.g. from a field in the database
