### PR TITLE
For Ruby v2.4.0 onward: https://ruby-doc.org/stdlib-2.4.0/libdoc/open…

### DIFF
--- a/lib/encrypted_strings/symmetric_cipher.rb
+++ b/lib/encrypted_strings/symmetric_cipher.rb
@@ -93,7 +93,7 @@ module EncryptedStrings
     
     private
       def build_cipher(type) #:nodoc:
-        cipher = OpenSSL::Cipher::Cipher.new(algorithm).send(type)
+        cipher = OpenSSL::Cipher.new(algorithm).send(type)
         cipher.pkcs5_keyivgen(password)
         cipher
       end


### PR DESCRIPTION
…ssl/rdoc/OpenSSL/Cipher/Cipher.html

The purpose of this pull request is to squash the deprecation warning: `warning: constant OpenSSL::Cipher::Cipher is deprecated`.

#3 
